### PR TITLE
SFAT-80 - changed port from 8082 to 9020

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 server:
-  port: 8082
+  port: 9020
 
 logging:
   level:


### PR DESCRIPTION
Updated to use port in preparation for merging change as part of SFAT-80 in infra repo