### PR TITLE
Expose the new `unit` property from DT API and store/expose to/from DB

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/AnswerHistory.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/AnswerHistory.java
@@ -10,5 +10,6 @@ public class AnswerHistory {
 
   String answerText;
   String answer;
+  Unit unit;
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/ConditionalInput.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/ConditionalInput.java
@@ -19,5 +19,5 @@ public class ConditionalInput {
    * <code>EnumSet.of(QuestionType.TEXT_INPUT ...)</code>
    */
   QuestionType type;
-
+  Unit unit;
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/Question.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/Question.java
@@ -12,5 +12,6 @@ public class Question {
   String text;
   String hint;
   QuestionType type;
+  Unit unit;
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/Unit.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/Unit.java
@@ -1,0 +1,28 @@
+package uk.gov.crowncommercial.dts.scale.service.gm.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Unit of value for numerical conditional input / question types
+ */
+public enum Unit {
+
+  @JsonProperty("currency")
+  CURRENCY,
+
+  @JsonProperty("quantity")
+  QUANTITY,
+
+  @JsonProperty("days")
+  DAYS,
+
+  @JsonProperty("weeks")
+  WEEKS,
+
+  @JsonProperty("months")
+  MONTHS,
+
+  @JsonProperty("years")
+  YEARS;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/entity/JourneyInstanceAnswer.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/entity/JourneyInstanceAnswer.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.FieldDefaults;
+import uk.gov.crowncommercial.dts.scale.service.gm.model.Unit;
 
 /**
  *
@@ -47,4 +48,8 @@ public class JourneyInstanceAnswer {
 
   @Column(name = "value_date")
   LocalDate valueDate;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "unit")
+  Unit unit;
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/entity/JourneyInstanceQuestion.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/entity/JourneyInstanceQuestion.java
@@ -10,6 +10,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.FieldDefaults;
 import uk.gov.crowncommercial.dts.scale.service.gm.model.QuestionType;
+import uk.gov.crowncommercial.dts.scale.service.gm.model.Unit;
 
 /**
  *
@@ -49,6 +50,10 @@ public class JourneyInstanceQuestion {
   @Enumerated(EnumType.STRING)
   @Column(name = "question_type")
   QuestionType type;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "unit")
+  Unit unit;
 
   public void addJourneyInstanceAnswer(final JourneyInstanceAnswer jia) {
     journeyInstanceAnswers.add(jia);

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/external/dt/DTQuestionDefinition.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/model/external/dt/DTQuestionDefinition.java
@@ -6,9 +6,10 @@ import lombok.Value;
 import uk.gov.crowncommercial.dts.scale.service.gm.model.AnswerDefinition;
 import uk.gov.crowncommercial.dts.scale.service.gm.model.Question;
 import uk.gov.crowncommercial.dts.scale.service.gm.model.QuestionType;
+import uk.gov.crowncommercial.dts.scale.service.gm.model.Unit;
 
 /**
- * Decision Tree service question definitionAnalagous to {@link Question}
+ * Decision Tree service question definition. Analogous to {@link Question}
  */
 @Value
 @Builder
@@ -20,5 +21,6 @@ public class DTQuestionDefinition {
   String pattern;
   QuestionType type;
   Set<AnswerDefinition> answerDefinitions;
+  Unit unit;
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/service/DecisionTreeService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/service/DecisionTreeService.java
@@ -102,9 +102,9 @@ public class DecisionTreeService {
 
     return new QuestionDefinitionList(
         dtQuestionDefinitionList.stream().map(dtQuestionDefinition -> {
-          Question question =
-              new Question(dtQuestionDefinition.getUuid(), dtQuestionDefinition.getText(),
-                  dtQuestionDefinition.getHint(), dtQuestionDefinition.getType());
+          Question question = new Question(dtQuestionDefinition.getUuid(),
+              dtQuestionDefinition.getText(), dtQuestionDefinition.getHint(),
+              dtQuestionDefinition.getType(), dtQuestionDefinition.getUnit());
 
           return new QuestionDefinition(question, null, null, null,
               dtQuestionDefinition.getAnswerDefinitions());


### PR DESCRIPTION
Last one I think - exposes the new property from the DT API and stores in / exposes it from the corresponding journey instance (history) tables for the results page.