### PR TITLE
SFC-932 - updated fuzzy search threshold to > 0.33

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/repository/SearchDomainRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/repository/SearchDomainRepo.java
@@ -19,14 +19,13 @@ public interface SearchDomainRepo extends JpaRepository<SearchDomain, Integer> {
   /**
    * This native query requires `create extension pg_trgm;` running on database.
    * 
-   * You can use a search similar to `SELECT * FROM search_terms WHERE
-   * SIMILARITY(search_term,'linen') > 0.1;` for finer grain control over matches.
-   * 
    * @param searchTerm
    * @return List of SearchDomain objects that have been fuzzy matched on searchTerm
    */
   @Query(
-      value = "SELECT DISTINCT journey_id\\:\\:varchar, modifier_journey_name, journey_selection_text, journey_selection_description FROM search_terms st INNER JOIN search_domains sd ON st.search_id = sd.search_id WHERE search_term % ?1",
+      value = "SELECT DISTINCT journey_id\\:\\:varchar, modifier_journey_name, journey_selection_text, journey_selection_description "
+          + "FROM search_terms st INNER JOIN search_domains sd ON st.search_id = sd.search_id "
+          + "WHERE SIMILARITY(search_term,?1) > 0.33",
       nativeQuery = true)
   List<Object[]> findBySearchTermFuzzyMatch(String searchTerm);
 


### PR DESCRIPTION
The old version is equivalent to `SIMILARITY(search_term,?1) > 0.3`. Ran some tests with a sample set of searches provided by Jai at 0.4, 0.33 and 0.34 thresholds - and 0.33 seemed to give the closest match. This will be coupled with a follow up PR to remove some remaining 'service' words from search terms