### PR TITLE
start GM Lite Journey when there are no match for the user input keyword

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/controller/GuidedMatchController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/gm/controller/GuidedMatchController.java
@@ -112,7 +112,18 @@ public class GuidedMatchController {
 
     log.debug("searchJourneys(search-term: {})", searchTerm);
 
-    return searchTermLookupService.searchJourneys(searchTerm);
+    List<SearchJourneyResponse>  searchTermResult = searchTermLookupService.searchJourneys(searchTerm);
+    
+    if (searchTermResult.isEmpty()) {
+        log.debug("Using GM Lite Journeys");
+
+    	SearchJourneyResponse sjr = new SearchJourneyResponse();
+        sjr.setJourneyId("c9dd4455-7d23-4822-9912-eab4da9fc5a2");
+        
+        searchTermResult.add(sjr);
+    }
+    
+    return searchTermResult;
   }
 
 }


### PR DESCRIPTION
Any search term that is unmatch in the search term database will now be returned with a GM Lite journey.